### PR TITLE
Migrate to prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rimraf": "^2.4.3"
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-pure-render": "^1.0.2"
   }
 }

--- a/src/renderWrapper.js
+++ b/src/renderWrapper.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shouldPureComponentUpdate from 'react-pure-render/function';
 


### PR DESCRIPTION
> React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.

https://reactjs.org/docs/typechecking-with-proptypes.html